### PR TITLE
elimination of notices in debug mode

### DIFF
--- a/cforms-admin.css
+++ b/cforms-admin.css
@@ -1138,6 +1138,9 @@ color: #999;
 color:#999!important;
 }
 
+.wrap p
+{clear:both}
+
 .showformfield .R {
 float:left;
 width:55%;
@@ -1151,6 +1154,7 @@ float:left;
 width:35%;
 margin:1px 0;
 padding:3px;
+clear:both;
 }
 
 .showformfield .L {
@@ -1171,13 +1175,9 @@ margin:5px 0 2px 0;
 display:inline-block;
 }
 
-.dataheader:after,
-.showformfield:after {
-content:".";
+.dataheader,
+.showformfield {
 display:block;
-height:0;
-clear:both;
-visibility:hidden;
 }
 
 /****************************************************************

--- a/cforms-global-settings.php
+++ b/cforms-global-settings.php
@@ -67,7 +67,27 @@ if ( isset($_REQUEST['deletetables']) ) {
 // Update Settings
 if( isset($_REQUEST['SubmitOptions']) ) {
 
-	$cformsSettings['global']['cforms_html5'] = $_REQUEST['cforms_html5']?'1':'0';
+	if (!isset($_REQUEST['cforms_html5']        ))   $_REQUEST['cforms_html5']   = "";
+	if (!isset($_REQUEST['cforms_show_quicktag']))   $_REQUEST['cforms_show_quicktag']= "";
+	if (!isset($_REQUEST['cforms_sec_qa']       ))   $_REQUEST['cforms_sec_qa']= "";
+	if (!isset($_REQUEST['cforms_codeerr']      ))   $_REQUEST['cforms_codeerr']= "";
+	if (!isset($_REQUEST['cforms_database']     ))   $_REQUEST['cforms_database']= "";
+	if (!isset($_REQUEST['cforms_showdashboard']))   $_REQUEST['cforms_showdashboard']= "";
+	if (!isset($_REQUEST['cforms_datepicker']   ))   $_REQUEST['cforms_datepicker']= "";
+	if (!isset($_REQUEST['cforms_dp_date']      ))   $_REQUEST['cforms_dp_date']= "";
+	if (!isset($_REQUEST['cforms_dp_days']      ))   $_REQUEST['cforms_dp_days']= "";
+	if (!isset($_REQUEST['cforms_dp_start']     ))   $_REQUEST['cforms_dp_start']= "";
+	if (!isset($_REQUEST['cforms_dp_months']    ))   $_REQUEST['cforms_dp_months']= "";
+    
+	if (!isset($_REQUEST['cforms_dp_prevY']     ))   $_REQUEST['cforms_dp_prevY']= "";
+	if (!isset($_REQUEST['cforms_dp_prevM']     ))   $_REQUEST['cforms_dp_prevM']= "";
+	if (!isset($_REQUEST['cforms_dp_nextY']     ))   $_REQUEST['cforms_dp_nextY']= "";
+	if (!isset($_REQUEST['cforms_dp_nextM']     ))   $_REQUEST['cforms_dp_nextM']= "";
+	if (!isset($_REQUEST['cforms_dp_close']     ))   $_REQUEST['cforms_dp_close']= "";
+	if (!isset($_REQUEST['cforms_dp_choose']    ))   $_REQUEST['cforms_dp_choose']= "";
+	if (!isset($_REQUEST['cforms_dp_Ybuttons']  ))   $_REQUEST['cforms_dp_Ybuttons']= "";
+		
+	$cformsSettings['global']['cforms_html5'] 		  = $_REQUEST['cforms_html5']?'1':'0';
 	$cformsSettings['global']['cforms_show_quicktag'] = $_REQUEST['cforms_show_quicktag']?'1':'0';
 	$cformsSettings['global']['cforms_sec_qa'] = 		$_REQUEST['cforms_sec_qa'];
 	$cformsSettings['global']['cforms_codeerr'] = 		$_REQUEST['cforms_codeerr'];
@@ -91,9 +111,46 @@ if( isset($_REQUEST['SubmitOptions']) ) {
 
  	$cformsSettings['global']['cforms_inexclude']['ex'] = '';
   if( $_REQUEST['cforms_inc-or-ex']=='exclude' )
+
+	if (!isset($_REQUEST['cforms_commentsuccess']))   $_REQUEST['cforms_commentsuccess']= "";
+	if (!isset($_REQUEST['cforms_commentWait']  ))    $_REQUEST['cforms_commentWait']= "";
+	if (!isset($_REQUEST['cforms_include']      ))    $_REQUEST['cforms_include']= "";
+	if (!isset($_REQUEST['cforms_commentParent']))    $_REQUEST['cforms_commentParent']= "";
+	if (!isset($_REQUEST['cforms_commentHTML']  ))    $_REQUEST['cforms_commentHTML']= "";
+	if (!isset($_REQUEST['cforms_commentInMod'] ))    $_REQUEST['cforms_commentInMod']= "";
+	if (!isset($_REQUEST['cforms_avatar']       ))    $_REQUEST['cforms_avatar']= "";
+
+	if (!isset($_REQUEST['cforms_crlfH']        ))    $_REQUEST['cforms_crlfH']= "";
+	if (!isset($_REQUEST['cforms_crlf']         ))    $_REQUEST['cforms_crlf']= "";
+
+	if (!isset($_REQUEST['cforms_upload_err1']  ))    $_REQUEST['cforms_upload_err1']= "";
+	if (!isset($_REQUEST['cforms_upload_err2']  ))    $_REQUEST['cforms_upload_err2']= "";
+	if (!isset($_REQUEST['cforms_upload_err3']  ))    $_REQUEST['cforms_upload_err3']= "";
+	if (!isset($_REQUEST['cforms_upload_err4']  ))    $_REQUEST['cforms_upload_err4']= "";
+	if (!isset($_REQUEST['cforms_upload_err5']  ))    $_REQUEST['cforms_upload_err5']= "";
+
+	if (!isset($_REQUEST['cforms_cap_i']        ))    $_REQUEST['cforms_cap_i']= "";
+	if (!isset($_REQUEST['cforms_cap_w']        ))    $_REQUEST['cforms_cap_w']= "";
+	if (!isset($_REQUEST['cforms_cap_h']        ))    $_REQUEST['cforms_cap_h']= "";
+	if (!isset($_REQUEST['cforms_cap_c']        ))    $_REQUEST['cforms_cap_c']= "";
+	if (!isset($_REQUEST['cforms_cap_l']        ))    $_REQUEST['cforms_cap_l']= "";
+	if (!isset($_REQUEST['cforms_cap_b']        ))    $_REQUEST['cforms_cap_b']= "";
+	if (!isset($_REQUEST['cforms_cap_f']        ))    $_REQUEST['cforms_cap_f']= "";
+	if (!isset($_REQUEST['cforms_cap_fo']       ))    $_REQUEST['cforms_cap_fo']= "";
+	if (!isset($_REQUEST['cforms_cap_foqa']     ))    $_REQUEST['cforms_cap_foqa']= "";
+	if (!isset($_REQUEST['cforms_cap_f1']       ))    $_REQUEST['cforms_cap_f1']= "";
+	if (!isset($_REQUEST['cforms_cap_f2']       ))    $_REQUEST['cforms_cap_f2']= "";
+	if (!isset($_REQUEST['cforms_cap_a1']       ))    $_REQUEST['cforms_cap_a1']= "";
+	if (!isset($_REQUEST['cforms_cap_a2']       ))    $_REQUEST['cforms_cap_a2']= "";
+	if (!isset($_REQUEST['cforms_cap_c1']       ))    $_REQUEST['cforms_cap_c1']= "";
+	if (!isset($_REQUEST['cforms_cap_c2']       ))    $_REQUEST['cforms_cap_c2']= "";
+	if (!isset($_REQUEST['cforms_cap_ac']       ))    $_REQUEST['cforms_cap_ac']= "";
+	if (!isset($_REQUEST['cforms_rss']          ))    $_REQUEST['cforms_rss']= "";
+	if (!isset($_REQUEST['cforms_rsscount']     ))    $_REQUEST['cforms_rsscount']= "";
+
   	$cformsSettings['global']['cforms_inexclude']['ex'] = '1';
 
- 	$cformsSettings['global']['cforms_inexclude']['ids'] = $_REQUEST['cforms_include'];
+	$cformsSettings['global']['cforms_inexclude']['ids'] = $_REQUEST['cforms_include'];
 
 	$cformsSettings['global']['cforms_commentsuccess'] =$_REQUEST['cforms_commentsuccess'];
 	$cformsSettings['global']['cforms_commentWait'] =  	$_REQUEST['cforms_commentWait'];
@@ -102,8 +159,8 @@ if( isset($_REQUEST['SubmitOptions']) ) {
 	$cformsSettings['global']['cforms_commentInMod'] =	$_REQUEST['cforms_commentInMod'];
 	$cformsSettings['global']['cforms_avatar'] =	   	$_REQUEST['cforms_avatar'];
 
+//?	$cformsSettings['global']['cforms_crlf']['h'] =	   	$_REQUEST['cforms_crlfH']?'1':'0';
 	$cformsSettings['global']['cforms_crlf']['b'] =	   	$_REQUEST['cforms_crlf']?'1':'0';
-
 	$cformsSettings['global']['cforms_smtp'] = null ;
 
 	$cformsSettings['global']['cforms_upload_err1'] = $_REQUEST['cforms_upload_err1'];
@@ -129,13 +186,13 @@ if( isset($_REQUEST['SubmitOptions']) ) {
 	$cap['c1']= $_REQUEST['cforms_cap_c1'];
 	$cap['c2']= $_REQUEST['cforms_cap_c2'];
 	$cap['ac']= $_REQUEST['cforms_cap_ac'];
-
+	
     ###	update new settings container
 	$cformsSettings['global']['cforms_rssall'] = $_REQUEST['cforms_rss']?true:false;
 	$cformsSettings['global']['cforms_rssall_count'] = $_REQUEST['cforms_rsscount'];
-    $cformsSettings['global']['cforms_captcha_def'] = $cap;
+	$cformsSettings['global']['cforms_captcha_def'] = $cap;
 
-    update_option('cforms_settings',$cformsSettings);
+	update_option('cforms_settings',$cformsSettings);
 
 	// Setup database tables ?
 	if ( isset($_REQUEST['cforms_database']) && $_REQUEST['cforms_database_new']=='true' ) {
@@ -189,7 +246,6 @@ if( isset($_REQUEST['SubmitOptions']) ) {
 			<?php
 		}
 	}
-
 }
 
 ?>

--- a/js/include/lib_database_getentries.php
+++ b/js/include/lib_database_getentries.php
@@ -140,6 +140,7 @@ if ($showIDs<>'') {
 
 					$passID = ($cformsSettings['form'.$no]['cforms'.$no.'_noid']) ? '':$entry->sub_id;
 					$fileInfoArr = array('name'=>strip_tags($val), 'path'=>$fileurl, 'subID'=>$passID);
+					$results[] = "";
 
 					if ( function_exists('my_cforms_logic') )
 						$fileInfoArr = my_cforms_logic( $results, $fileInfoArr, 'fileDestinationTrackingPage');
@@ -147,7 +148,7 @@ if ($showIDs<>'') {
 					if( ! array_key_exists('modified', $fileInfoArr) )
 						$fileInfoArr['name'] = $subID . $fileInfoArr['name'];
 					
-					$fileurl = $fileInfoArr['path'] . '/' . $fileInfoArr['name'] . $format;
+					$fileurl = $fileInfoArr['path'] . '/' . $fileInfoArr['name']; //. $format;
 					
 					echo '<div class="showformfield meta"><div class="L">';
 					echo substr($name, 0,strpos($name,'[*'));

--- a/lib_activate.php
+++ b/lib_activate.php
@@ -44,6 +44,12 @@ $cformsSettings['global']['cforms_style']['dear'] 		= 'style="margin:0.5em 30px;
 $cformsSettings['global']['cforms_style']['confp'] 		= 'style="margin:0.5em 30px;"';
 $cformsSettings['global']['cforms_style']['confirmationmsg'] = 'style="margin:4em 30px 0; padding-bottom:1em; font-size:80%; color:#aaa; font-family:Tahoma,Arial;"';
 
+cforms2_setINI('global','cforms_showdashboard', '');
+if (!isset($cformsSettings['global']['cforms_inexclude']['ex']))
+	$cformsSettings['global']['cforms_inexclude']['ex'] = '';
+if (!isset($cformsSettings['global']['cforms_inexclude']['ids']))
+	$cformsSettings['global']['cforms_inexclude']['ids'] = '';
+cforms2_setINI('global','cforms_no_css', '');
 
 ### file upload
 $wp_upload_dir = wp_upload_dir();
@@ -240,6 +246,8 @@ if ( $wpdb->get_var("show tables like '$wpdb->cformsdata'") == $wpdb->cformsdata
     }
 }
 }
+
+//cforms2_setINI('global','cforms_showdashboard', '');
 
 ### check if option is set
 function cforms2_setINI($s,$v,$d) {

--- a/lib_ajax.php
+++ b/lib_ajax.php
@@ -163,8 +163,8 @@ function cforms2_submitcomment() {
 
 			### remove [id: ] first
 			if ( strpos($field_name,'[id:')!==false ){
-				
-				preg_match('/^([^\[]*)\[id:([^\|]+(\[\])?)\]([^\|]*).*/',$field_name,$input_name); // 2.6.2012  
+				preg_match('/^([^\[]*)\[id:([^\|\]]+(\[\])?)\]([^\|]*).*/',$field_name,$input_name); // CB 2.4.2014  
+//				preg_match('/^([^\[]*)\[id:([^\|]+(\[\])?)\]([^\|]*).*/',$field_name,$input_name); // 2.6.2012  
 				$field_name = $input_name[1].$input_name[4];
 				$customTrackingID	= cforms2_sanitize_ids( $input_name[2] );
 

--- a/lib_functions.php
+++ b/lib_functions.php
@@ -53,7 +53,7 @@ function cforms2_download(){
 	    	$buffer .= cforms2_save_array($cformsSettings);
 			$filename = 'all-cforms-settings.txt';
 		}
-        ob_end_clean();
+        if (ob_get_contents())ob_end_clean();
 		header('Pragma: public;');
 		header('Expires: 0;');
 		header('Cache-Control: must-revalidate, post-check=0, pre-check=0;');
@@ -76,6 +76,7 @@ function cforms2_save_array($vArray){
 
     // Go through the given array
     reset($vArray);
+	$i=0;
     while (true)
     {
         $Current = current($vArray);

--- a/lib_nonajax.php
+++ b/lib_nonajax.php
@@ -68,6 +68,7 @@ if( isset($_POST['sendbutton'.$no]) && $all_valid ) {
 				$field_stat = explode('$#$', $cformsSettings['form'.$no]['cforms'.$no.'_count_field_' . $i ]);
 			else
 				$field_stat = explode('$#$', $customfields[$i-1]);
+			$field_stat[] = "";
 
 			###  filter non input fields
 			while ( in_array($field_stat[1],array('fieldsetstart','fieldsetend','textonly','captcha','verification')) ) {
@@ -91,6 +92,7 @@ if( isset($_POST['sendbutton'.$no]) && $all_valid ) {
                     $field_stat = explode('$#$', $cformsSettings['form'.$no]['cforms'.$no.'_count_field_' . $i ]);
                 else
                     $field_stat = explode('$#$', $customfields[$i-1]);
+				$field_stat[] = "";
 
                 if( $field_stat[1] == '')
                         break 2; ###  all fields searched, break both while & for
@@ -110,7 +112,8 @@ if( isset($_POST['sendbutton'.$no]) && $all_valid ) {
 				if ( strpos($tmpName,'[id:')!==false ){
 					$isFieldArray = strpos($tmpName,'[]');
 
-				preg_match('/^([^\[]*)\[id:([^\|]+(\[\])?)\]([^\|]*).*/',$tmpName,$input_name); // 2.6.2012  
+				preg_match('/^([^\[]*)\[id:([^\|\]]+(\[\])?)\]([^\|]*).*/',$tmpName,$input_name); // CB 2.4.2014  
+//				preg_match('/^([^\[]*)\[id:([^\|]+(\[\])?)\]([^\|]*).*/',$tmpName,$input_name); // 2.6.2012  
 				$field_name = $input_name[1].$input_name[4];
 				$customTrackingID	= cforms2_sanitize_ids( $input_name[2] );
 
@@ -134,11 +137,13 @@ if( isset($_POST['sendbutton'.$no]) && $all_valid ) {
 			
 			###  dissect field
 		    $obj = explode('|', $field_name,3);
+			$obj[]="";
 			$defaultval = stripslashes($obj[1]);
 
 			###  strip out default value
 			$field_name = $obj[0];
-
+			if (!isset ($_POST[$current_field])) 	
+				$_POST[$current_field] = "";
 			###  special Tell-A-Friend fields
 			if ( !$taf_friendsemail && $field_type=='friendsemail' && $field_stat[3]=='1')
 					$field_email = $taf_friendsemail = $_POST[$current_field];
@@ -203,7 +208,7 @@ if( isset($_POST['sendbutton'.$no]) && $all_valid ) {
  		}
  		else if ( $field_type == "upload" ){
 
-			if ( is_array($file) && is_array($file['name']) ) {
+			if ( is_array($file) && is_array($file['name']) && isset($file['name'][$filefield])) {
 				### $fsize = $file['size'][$filefield]/1000;
 				$value = str_replace(' ','_',$file['name'][$filefield++]);
 			}else{
@@ -271,7 +276,7 @@ if( isset($_POST['sendbutton'.$no]) && $all_valid ) {
         $inc='';
         $trackname = trim( ($field_type == "upload") ? $field_name.'[*'.($no==''?1:$no).']' : $field_name );
         if ( array_key_exists($trackname, $track) ){
-            if ( $trackinstance[$trackname]==''  )
+            if ( !isset ($trackinstance[$trackname]) || $trackinstance[$trackname]==''  )
                 $trackinstance[$trackname]=2;
             $inc = '___'.($trackinstance[$trackname]++);
         }
@@ -523,7 +528,8 @@ if( isset($_POST['sendbutton'.$no]) && $all_valid ) {
 	    if( $sentadmin == 1 ) {
 
 				#debug
-				cforms2_dbg("is CC: = $ccme, active = {$trackf[data][$ccme]} | ");
+				if (!isset($trackf['data'][$ccme]))  $trackf['data'][$ccme] = '';
+				cforms2_dbg("is CC: = $ccme, active = {$trackf['data'][$ccme]} | ");
 
 	            ###  send copy or notification?
                 ###  not if no email & already CC'ed				

--- a/lib_options_err.php
+++ b/lib_options_err.php
@@ -17,6 +17,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+if (!isset($cformsSettings['form'.$no]['cforms'.$no.'_confirmerr']))
+	$cformsSettings['form'.$no]['cforms'.$no.'_confirmerr'] = "";
 $userconfirm = $cformsSettings['form'.$no]['cforms'.$no.'_confirmerr'];
 
 echo '<form name="errmessages" action="#" method="post"><input type="hidden" name="switchform" value="'.$noDISP.'"/>';

--- a/lib_options_sub.php
+++ b/lib_options_sub.php
@@ -109,28 +109,52 @@
 
 	### update new settings container
 	$cformsSettings['form'.$no]['cforms'.$no.'_fname'] =          preg_replace( array('/\\\+/','/\//','/"/'), array('\\','-','\''), $_REQUEST['cforms_fname'] );
-
-
+	if (!isset($_REQUEST['cforms_upload_noid']))
+		$_REQUEST['cforms_upload_noid'] = "";
 	$cformsSettings['form'.$no]['cforms'.$no.'_noid'] =           $_REQUEST['cforms_upload_noid']?'1':'0';
+	if (!isset($_REQUEST['cforms_upload_dir']))
+		$_REQUEST['cforms_upload_dir'] = "";
+	if (!isset($_REQUEST['cforms_upload_dir_url']))
+		$_REQUEST['cforms_upload_dir_url'] = "";
 	if( $uploadfield && $_REQUEST['cforms_upload_dir']<>'' )
 		$cformsSettings['form'.$no]['cforms'.$no.'_upload_dir'] =     $_REQUEST['cforms_upload_dir'].'$#$'.$_REQUEST['cforms_upload_dir_url'];
-	$cformsSettings['form'.$no]['cforms'.$no.'_upload_ext'] =     $_REQUEST['cforms_upload_ext'];
-	$cformsSettings['form'.$no]['cforms'.$no.'_upload_size'] =    $_REQUEST['cforms_upload_size'];
-	$cformsSettings['form'.$no]['cforms'.$no.'_noattachments'] =  $_REQUEST['cforms_noattachments']?'1':'0';
+	$cformsSettings['form'.$no]['cforms'.$no.'_upload_ext'] =     (isset($_REQUEST['cforms_upload_ext'])) ?  $_REQUEST['cforms_upload_ext']:"";
+	$cformsSettings['form'.$no]['cforms'.$no.'_upload_size'] =    (isset($_REQUEST['cforms_upload_size'])) ? $_REQUEST['cforms_upload_size']:"";
+	$cformsSettings['form'.$no]['cforms'.$no.'_noattachments'] =  (isset($_REQUEST['cforms_noattachments']) && $_REQUEST['cforms_noattachments'])?'1':'0';
 
+	$cformsSettings['form'.$no]['cforms'.$no.'_submit_text'] =   isset($_REQUEST['cforms_submit_text']) ? $_REQUEST['cforms_submit_text']:"";
+	$cformsSettings['form'.$no]['cforms'.$no.'_working'] =       isset($_REQUEST['cforms_working']) ? $_REQUEST['cforms_working']:0;
+  	$cformsSettings['form'.$no]['cforms'.$no.'_required'] =      isset($_REQUEST['cforms_required']) ? $_REQUEST['cforms_required']:"";
+  	$cformsSettings['form'.$no]['cforms'.$no.'_emailrequired'] = isset($_REQUEST['cforms_emailrequired']) ? $_REQUEST['cforms_emailrequired']:"";
+	$cformsSettings['form'.$no]['cforms'.$no.'_success'] =       isset($_REQUEST['cforms_success']) ? $_REQUEST['cforms_success']:"";
+	$cformsSettings['form'.$no]['cforms'.$no.'_failure'] =       isset($_REQUEST['cforms_failure']) ? $_REQUEST['cforms_failure']:"";
 
-	$cformsSettings['form'.$no]['cforms'.$no.'_submit_text'] =   $_REQUEST['cforms_submit_text'];
-	$cformsSettings['form'.$no]['cforms'.$no.'_working'] =       $_REQUEST['cforms_working'];
-  	$cformsSettings['form'.$no]['cforms'.$no.'_required'] =      $_REQUEST['cforms_required'];
-  	$cformsSettings['form'.$no]['cforms'.$no.'_emailrequired'] = $_REQUEST['cforms_emailrequired'];
-	$cformsSettings['form'.$no]['cforms'.$no.'_success'] =       $_REQUEST['cforms_success'];
-	$cformsSettings['form'.$no]['cforms'.$no.'_failure'] =       $_REQUEST['cforms_failure'];
-	$cformsSettings['form'.$no]['cforms'.$no.'_popup'] =         ($_REQUEST['cforms_popup1']?'y':'n').($_REQUEST['cforms_popup2']?'y':'n') ;
-	$cformsSettings['form'.$no]['cforms'.$no.'_showpos'] =       ($_REQUEST['cforms_showposa']?'y':'n').($_REQUEST['cforms_showposb']?'y':'n').
-																 ($_REQUEST['cforms_errorLI']?'y':'n').($_REQUEST['cforms_errorINS']?'y':'n').
-																 ($_REQUEST['cforms_jump']?'y':'n') ;
+	if (!isset($_REQUEST['cforms_popup1']))   $_REQUEST['cforms_popup1']="";
+	if (!isset($_REQUEST['cforms_popup2']))   $_REQUEST['cforms_popup2']="";
+	if (!isset($_REQUEST['cforms_showposa'])) $_REQUEST['cforms_showposa']="";
+	if (!isset($_REQUEST['cforms_showposb'])) $_REQUEST['cforms_showposb']="";
+	if (!isset($_REQUEST['cforms_errorLI']))  $_REQUEST['cforms_errorLI']="";
+	if (!isset($_REQUEST['cforms_errorINS'])) $_REQUEST['cforms_errorINS']="";
 
-	$cformsSettings['form'.$no]['cforms'.$no.'_formaction'] =     $_REQUEST['cforms_formaction']?true:false;
+	$cformsSettings['form'.$no]['cforms'.$no.'_popup'] =   ($_REQUEST['cforms_popup1']?'y':'n').($_REQUEST['cforms_popup2']?'y':'n') ;
+	$cformsSettings['form'.$no]['cforms'.$no.'_showpos'] = ($_REQUEST['cforms_showposa']?'y':'n').($_REQUEST['cforms_showposb']?'y':'n').
+																	($_REQUEST['cforms_errorLI']?'y':'n').($_REQUEST['cforms_errorINS']?'y':'n').
+																	($_REQUEST['cforms_jump']?'y':'n') ;
+
+    if (!isset($_REQUEST['cforms_formaction']))  $_REQUEST['cforms_formaction']  = "";
+    if (!isset($_REQUEST['cforms_dontclear']))   $_REQUEST['cforms_dontclear']   = "";
+	if (!isset($_REQUEST['cforms_dashboard']))   $_REQUEST['cforms_dashboard']   = "";
+	if (!isset($_REQUEST['cforms_notracking']))  $_REQUEST['cforms_notracking']  = "";
+	if (!isset($_REQUEST['cforms_customnames'])) $_REQUEST['cforms_customnames'] = "";
+	if (!isset($_REQUEST['cforms_hide']))		 $_REQUEST['cforms_hide']		 = "";
+
+	if (!isset($_REQUEST['cforms_startdate']))  $_REQUEST['cforms_startdate'] ="";
+	if (!isset($_REQUEST['cforms_starttime']))  $_REQUEST['cforms_starttime'] ="";
+	if (!isset($_REQUEST['cforms_enddate']))    $_REQUEST['cforms_enddate']   ="";
+	if (!isset($_REQUEST['cforms_endtime']))    $_REQUEST['cforms_endtime']   ="";
+	
+	
+	$cformsSettings['form'.$no]['cforms'.$no.'_formaction'] =    $_REQUEST['cforms_formaction']?true:false;
 	$cformsSettings['form'.$no]['cforms'.$no.'_dontclear'] =     $_REQUEST['cforms_dontclear']?true:false;
 	$cformsSettings['form'.$no]['cforms'.$no.'_dashboard'] =	 $_REQUEST['cforms_dashboard']?'1':'0';
     $cformsSettings['form'.$no]['cforms'.$no.'_notracking'] =    $_REQUEST['cforms_notracking']?true:false;
@@ -147,14 +171,24 @@
     $cformsSettings['form'.$no]['cforms'.$no.'_enddate'] =  					preg_replace("/\\\+/", "\\",$_REQUEST['cforms_enddate']).' '.
     																			preg_replace("/\\\+/", "\\",$_REQUEST['cforms_endtime']);
 	if( isset($_REQUEST['cforms_limittxt']) )
-		$cformsSettings['form'.$no]['cforms'.$no.'_limittxt'] =   				$_REQUEST['cforms_limittxt'];
+		$cformsSettings['form'.$no]['cforms'.$no.'_limittxt'] = $_REQUEST['cforms_limittxt'];
+	else
+		$cformsSettings['form'.$no]['cforms'.$no.'_limittxt'] = "";
 
+	if (!isset($_REQUEST['cforms_redirect']))        $_REQUEST['cforms_redirect']="";
+	if (!isset($_REQUEST['cforms_redirect_page']))   $_REQUEST['cforms_redirect_page']="";
+	if (!isset($_REQUEST['cforms_action']))          $_REQUEST['cforms_action']="";
+	if (!isset($_REQUEST['cforms_action_page']))     $_REQUEST['cforms_action_page']="";
+	if (!isset($_REQUEST['cforms_rss']))             $_REQUEST['cforms_rss']="";
+	if (!isset($_REQUEST['cforms_rsscount']))        $_REQUEST['cforms_rsscount']="";
+	
 	$cformsSettings['form'.$no]['cforms'.$no.'_redirect'] =       $_REQUEST['cforms_redirect']?true:false;
 	$cformsSettings['form'.$no]['cforms'.$no.'_redirect_page'] =  preg_replace("/\\\+/", "\\",$_REQUEST['cforms_redirect_page']);
 	$cformsSettings['form'.$no]['cforms'.$no.'_action'] =         $_REQUEST['cforms_action']?'1':'0';
 	$cformsSettings['form'.$no]['cforms'.$no.'_action_page'] =    preg_replace("/\\\+/", "\\",$_REQUEST['cforms_action_page']);
 	$cformsSettings['form'.$no]['cforms'.$no.'_rss'] =            $_REQUEST['cforms_rss']?true:false;
 	$cformsSettings['form'.$no]['cforms'.$no.'_rss_count'] =      $_REQUEST['cforms_rsscount'];
+	
 	if( isset($_REQUEST['cforms_rssfields']) ){
 		$i=1;
 		foreach($_REQUEST['cforms_rssfields'] as $e) {
@@ -162,6 +196,20 @@
         }
 	}
 
+	if (!isset($_REQUEST['cforms_emailoff']     ))  $_REQUEST['cforms_emailoff']= "";
+	if (!isset($_REQUEST['cforms_emptyoff']     ))  $_REQUEST['cforms_emptyoff']= "";
+	if (!isset($_REQUEST['cforms_fromemail']    ))  $_REQUEST['cforms_fromemail']= "";
+	if (!isset($_REQUEST['cforms_email']        ))  $_REQUEST['cforms_email']= "";
+	if (!isset($_REQUEST['cforms_bcc']          ))  $_REQUEST['cforms_bcc']= "";
+	if (!isset($_REQUEST['cforms_subject']      ))  $_REQUEST['cforms_subject']= "";
+	if (!isset($_REQUEST['emailprio']           ))  $_REQUEST['emailprio']= "";
+	if (!isset($_REQUEST['cforms_header']       ))  $_REQUEST['cforms_header']= "";
+	if (!isset($_REQUEST['cforms_header_html']  ))  $_REQUEST['cforms_header_html']= "";
+	if (!isset($_REQUEST['cforms_formdata_txt'] ))  $_REQUEST['cforms_formdata_txt']= "";
+	if (!isset($_REQUEST['cforms_formdata_html']))  $_REQUEST['cforms_formdata_html']= "";
+	if (!isset($_REQUEST['cforms_admin_html']   ))  $_REQUEST['cforms_admin_html']= "";
+	if (!isset($_REQUEST['cforms_user_html']    ))  $_REQUEST['cforms_user_html']= "";
+	if (!isset($_REQUEST['cforms_space']        ))  $_REQUEST['cforms_space']= "";
 
 	$cformsSettings['form'.$no]['cforms'.$no.'_emailoff'] =		 $_REQUEST['cforms_emailoff']?'1':'0';
 	$cformsSettings['form'.$no]['cforms'.$no.'_emptyoff'] =		 $_REQUEST['cforms_emptyoff']?'1':'0';
@@ -178,7 +226,12 @@
 
     ## quickly get old vals
     $t=explode('$#$',$cformsSettings['form'.$no]['cforms'.$no.'_csubject']);
-
+	if( !isset($_REQUEST['cforms_confirm']))  $_REQUEST['cforms_confirm'] = "";
+	if( !isset($_REQUEST['cforms_cattachment']))  $_REQUEST['cforms_cattachment'] = "";
+	if( !isset($_REQUEST['cforms_csubject']))     $_REQUEST['cforms_csubject'] = "";
+	if( !isset($_REQUEST['cforms_cmsg']))         $_REQUEST['cforms_cmsg'] = "";
+	if( !isset($_REQUEST['cforms_cmsg_html']))    $_REQUEST['cforms_cmsg_html'] = "";
+	
     if( $_REQUEST['cforms_confirm'] && $cformsSettings['form'.$no]['cforms'.$no.'_confirm']==1 ){
         $t[0] = 													  preg_replace("/\\\+/", "\\",$_REQUEST['cforms_csubject']);
 	    $cformsSettings['form'.$no]['cforms'.$no.'_cattachment'][0] = $_REQUEST['cforms_cattachment'];
@@ -194,19 +247,30 @@
 
     $cformsSettings['form'.$no]['cforms'.$no.'_csubject'] =		$t[0].'$#$'.$t[1];
 
-
-	$cformsSettings['form'.$no]['cforms'.$no.'_mp']['mp_form'] = 	 $_REQUEST['cforms_mp_form']?true:false;
+	if (!isset($_REQUEST['cforms_mp_form'])) $_REQUEST['cforms_mp_form'] = "";
+	if (!isset($_REQUEST['cforms_mp_next'])) $_REQUEST['cforms_mp_next'] = "";
+	$cformsSettings['form'.$no]['cforms'.$no.'_mp']['mp_form'] = 	 (isset($_REQUEST['cforms_mp_form']) && $_REQUEST['cforms_mp_form'])?true:false;
 	if ( $_REQUEST['cforms_mp_form']==true && $_REQUEST['cforms_mp_next']=='' )
 		$cformsSettings['form'.$no]['cforms'.$no.'_mp']['mp_next'] = -1;
     else
 		$cformsSettings['form'.$no]['cforms'.$no.'_mp']['mp_next'] = $_REQUEST['cforms_mp_next'];
 
+	if( !isset($_REQUEST['cforms_mp_first']))        $_REQUEST['cforms_mp_first']="";
+	if( !isset($_REQUEST['cforms_mp_email']))        $_REQUEST['cforms_mp_email']="";
+	if( !isset($_REQUEST['cforms_mp_reset']))        $_REQUEST['cforms_mp_reset']="";
+	if( !isset($_REQUEST['cforms_mp_resettext']))    $_REQUEST['cforms_mp_resettext']="";
+	if( !isset($_REQUEST['cforms_mp_back']))         $_REQUEST['cforms_mp_back']="";
+	if( !isset($_REQUEST['cforms_mp_backtext']))     $_REQUEST['cforms_mp_backtext']="";
+	
 	$cformsSettings['form'.$no]['cforms'.$no.'_mp']['mp_first'] = 		$_REQUEST['cforms_mp_first']?true:false;
 	$cformsSettings['form'.$no]['cforms'.$no.'_mp']['mp_email'] =  		$_REQUEST['cforms_mp_email']?true:false;
 	$cformsSettings['form'.$no]['cforms'.$no.'_mp']['mp_reset'] = 		$_REQUEST['cforms_mp_reset']?true:false;
 	$cformsSettings['form'.$no]['cforms'.$no.'_mp']['mp_resettext']=	$_REQUEST['cforms_mp_resettext'];
 	$cformsSettings['form'.$no]['cforms'.$no.'_mp']['mp_back']     = 	$_REQUEST['cforms_mp_back']?true:false;
 	$cformsSettings['form'.$no]['cforms'.$no.'_mp']['mp_backtext'] =	$_REQUEST['cforms_mp_backtext'];
+	if( !isset($_REQUEST['cforms_mp_form'])) $_REQUEST['cforms_mp_form']="";
+	if( !isset($_REQUEST['cforms_ajax'])) $_REQUEST['cforms_ajax'] = "";
+	if( !isset($_REQUEST['cforms_tafCC'])) $_REQUEST['cforms_tafCC'] = "";
 	if( $_REQUEST['cforms_mp_form'] ){
 		$cformsSettings['form'.$no]['cforms'.$no.'_ajax']       = '0';
 		$cformsSettings['form'.$no]['cforms'.$no.'_dontclear']  = false; // NOTE that it can't be set with MP!
@@ -221,14 +285,14 @@
 		$cformsSettings['form'.$no]['cforms'.$no.'_tellafriend'] = 	'31';
 
 	if ( isset($_REQUEST['cforms_tellafriend']) )
-		$cformsSettings['form'.$no]['cforms'.$no.'_tellafriend'] =	'1'.($_REQUEST['cforms_tafdefault']?'1':'0') ;
+		$cformsSettings['form'.$no]['cforms'.$no.'_tellafriend'] =	'1'.(isset($_REQUEST['cforms_tafdefault']) && $_REQUEST['cforms_tafdefault']?'1':'0') ;
 
 
 	if ( isset($_REQUEST['cforms_commentrep']) )
-		$cformsSettings['form'.$no]['cforms'.$no.'_tellafriend'] =	'2'.($_REQUEST['cforms_commentXnote']?'1':'0') ;
+		$cformsSettings['form'.$no]['cforms'.$no.'_tellafriend'] =	'2'.(isset($_REQUEST['cforms_commentXnote']) && $_REQUEST['cforms_commentXnote']?'1':'0') ;
 
 
-	$cformsSettings['form'.$no]['cforms'.$no.'_tracking'] =      preg_replace("/\\\+/", "\\",$_REQUEST['cforms_tracking']);
+	$cformsSettings['form'.$no]['cforms'.$no.'_tracking'] =      preg_replace("/\\\+/", "\\",isset($_REQUEST['cforms_tracking'])&& $_REQUEST['cforms_tracking']);
 
 
 	### reorder fields
@@ -269,6 +333,5 @@
 	        }
 
 	}
-
     update_option('cforms_settings',$cformsSettings);
 	echo '<div id="message" class="updated fade"><p>'.__('Form settings updated.', 'cforms').'</p>'.$usermsg.'</div>';


### PR DESCRIPTION

- cforms-admin.css : The tracking page had alignment problems in the "view" area and i was able to fix them reintroducing the dataheader class as shown
- cforms-global-settings.php: all the changes are to eliminate the "unknown offset" notice.
- cforms.php: most changes are to eliminate the "unknown offset" notice, except line 196 + which is to avoid the generic upload error of PHP. $server_upload_size_error is used to keep track of this error in the rest of the code.
- lib_database_getentries.php: $results[] is used without having been defined at all - rathe then deleting it I set it to a blank array, in case of possible future use (?). Also $format was used without having been defined, and in this case I commented it.
- lib_activate:changes are to avoid "undefined " message.
- lib_aux.php: Improved version of cforms2_dbg to display the real line where the debug takes place. All other changes to avoid "undefined".
- lib_ajax line 6-7: preg_match corrected because in case of a field definition like 
nazionality[id:nazionality]#[nazione]|-#Afghanistan| etc... input_name[1] would be as follows:
nazionality]#[nazionality. Adding \] in the first match pattern which becomes ([^\|\]]+(\[\])?) from ([^\|]+(\[\])?) fixed the problem.
- lib_functions.php: there were errors at plugin activation time, so i introduced 
if (ob_get_contents())  in front of ob_end_clean() and initialized $i
- lib_nonajax.php: all changes are to avoid "undefined " message. preg_match at line 196, as in lib_ajax.php
- lib_options_err.php: all changes are to avoid "undefined " message.
- lib_options_sub.php: all changes are to avoid "undefined " message.
- lib_validate: line 33 to deal with upload generic error. Same for line 45: when the upload generic error occurs, PHP clears completely the POST so the validation loop has to be skipped.
line 97, preg_match as in lib_ajax.php. All other changes are to avoid "undefined " message.




